### PR TITLE
Fix missing variables

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -92,6 +92,32 @@ variable "max_ttl" {
   type    = number
 }
 
+variable "forward_query_string" {
+  type        = bool
+  default     = false
+  description = "Enable query string cache in default cache behavior"
+}
+
+variable "query_string_cache_keys" {
+  default     = []
+  description = "Which query strings will be cached in default cache behavior"
+}
+
+variable "forward_header_values" {
+  default     = []
+  description = "Which headers will be cached in default cache behavior"
+}
+
+variable "forward_cookies" {
+  default     = "none"
+  description = "Which cookies will be cached in default cache behavior"
+}
+
+variable "forward_cookies_whitelist_name" {
+  default     = []
+  description = "Which cookies will be cached in default cache behavior if forward_cookies value is whitelist"
+}
+
 variable "viewer_protocol_policy" {
   type    = string
   default = "redirect-to-https"

--- a/variables.tf
+++ b/variables.tf
@@ -83,12 +83,12 @@ variable "min_ttl" {
 }
 
 variable "default_ttl" {
-  default = 0
+  default = 86400
   type    = number
 }
 
 variable "max_ttl" {
-  default = 0
+  default = 31536000
   type    = number
 }
 


### PR DESCRIPTION
There will a missing variable problem when not provide `cache_policy_id` argument. 
(https://github.com/idfer/terraform-aws-cloudfront-s3-website/blob/ae887296a60f33839e7914a70a80818d7e57b2c9/main.tf#L248)